### PR TITLE
Added A Controlled Multiplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+__pycache__

--- a/QArithmetic.py
+++ b/QArithmetic.py
@@ -1,5 +1,5 @@
 from math import pi
-from qiskit import QuantumRegister
+from qiskit import QuantumRegister, QuantumCircuit
 from qft import qft, iqft, cqft, ciqft, ccu1
 
 ################################################################################
@@ -248,6 +248,16 @@ def full_qr(qr):
 def mult(circ, a, b, c, n):
     for i in range (0, n):
         cadd(circ, a[i], b, sub_qr(c, i, n+i), n)
+
+def cmult(circ, control, a, b, c, n):
+    qa = QuantumRegister(len(a))
+    qb = QuantumRegister(len(b))
+    qc = QuantumRegister(len(c))
+    tempCircuit = QuantumCircuit(qa, qb, qc)
+    mult(tempCircuit, qa, qb, qc, n)
+    tempCircuit = tempCircuit.control(1) #Add Decomposition after pull request inclusion #5446 on terra
+    print("Remember To Decompose after release >0.16.1")
+    circ.compose(tempCircuit, qubits=full_qr(control) + full_qr(a) + full_qr(b) + full_qr(c), inplace=True)
 
 ################################################################################
 # Division Circuit

--- a/QArithmetic.py
+++ b/QArithmetic.py
@@ -238,6 +238,9 @@ def sub_qr(qr, x, y):
         sub = sub + [(qr[i])] # I think this was supposed to point to specific qubits
     return sub
 
+def full_qr(qr):
+    return sub_qr(qr, 0, len(qr) - 1)
+
 # Computes the product c=a*b.
 # a has length n.
 # b has length n.

--- a/QArithmetic.py
+++ b/QArithmetic.py
@@ -235,7 +235,7 @@ def sub_ripple_ex(circ, a, b, s, n):
 def sub_qr(qr, x, y):
     sub = []
     for i in range (x, y+1):
-        sub = sub + [(qr, i)]
+        sub = sub + [(qr[i])] # I think this was supposed to point to specific qubits
     return sub
 
 # Computes the product c=a*b.

--- a/examples/test_cmult.py
+++ b/examples/test_cmult.py
@@ -1,0 +1,34 @@
+# Import the Qiskit SDK
+from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister
+from qiskit import execute, Aer
+from QArithmetic import cmult
+
+# Input N
+N = 3
+
+c = QuantumRegister(1)
+a = QuantumRegister(N)
+b = QuantumRegister(N)
+m = QuantumRegister(2*N)
+
+cm = ClassicalRegister(2*N)
+
+qc = QuantumCircuit(c, a, b, m, cm)
+
+# Input
+# a = 010 = 2
+qc.x(a[1])
+# b = 011 = 3
+qc.x(b[0])
+qc.x(b[1])
+qc.x(c)# turns operation on
+
+cmult(qc, c, a, b, m, N)
+
+qc.measure(m, cm)
+
+backend_sim = Aer.get_backend('qasm_simulator')
+job_sim = execute(qc, backend_sim)
+result_sim = job_sim.result()
+
+print(result_sim.get_counts(qc))


### PR DESCRIPTION
I have added a `cmult` method within QArithmetic.py which adds a control bit onto the previously existing `mult` method. I also updated the `sub_qr` method as I believe that qiskit syntax has changed since it was added and if using the current version of qiskit the `mult` method would not run. I have chosen to add a controlled multiplication not only because it is an important standalone method but also as it is necessary for adding an exponential circuit which I plan to work on next.