### PR TITLE
Add overflow

### DIFF
--- a/QArithmetic.ipynb
+++ b/QArithmetic.ipynb
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {
     "slideshow": {
      "slide_type": "subslide"
@@ -94,7 +94,7 @@
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "{'11001 01110': 1024}\n"
+      "{'11001 1110': 1024}\n"
      ]
     }
    ],
@@ -104,9 +104,9 @@
     "from QArithmetic import add\n",
     "\n",
     "# Registers and circuit.\n",
-    "a = QuantumRegister(5)\n",
+    "a = QuantumRegister(4)\n",
     "b = QuantumRegister(5)\n",
-    "ca = ClassicalRegister(5)\n",
+    "ca = ClassicalRegister(4)\n",
     "cb = ClassicalRegister(5)\n",
     "qc = QuantumCircuit(a, b, ca, cb)\n",
     "\n",
@@ -119,7 +119,7 @@
     "qc.x(b[3])\n",
     "\n",
     "# Add the numbers, so |a>|b> to |a>|a+b>.\n",
-    "add(qc, a, b, 5)\n",
+    "add(qc, a, b, 4)\n",
     "\n",
     "# Measure the results.\n",
     "qc.measure(a, ca)\n",
@@ -231,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {
     "slideshow": {
      "slide_type": "subslide"
@@ -239,10 +239,10 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "{'000110': 1024}\n"
+      "{'0110': 1024}\n"
      ]
     }
    ],
@@ -250,19 +250,19 @@
     "from QArithmetic import mult\n",
     "\n",
     "# Registers and circuit.\n",
-    "a = QuantumRegister(3)\n",
-    "b = QuantumRegister(3)\n",
-    "m = QuantumRegister(6)\n",
-    "cm = ClassicalRegister(6)\n",
+    "a = QuantumRegister(2)\n",
+    "b = QuantumRegister(2)\n",
+    "m = QuantumRegister(4)\n",
+    "cm = ClassicalRegister(4)\n",
     "qc = QuantumCircuit(a, b, m, cm)\n",
     "\n",
     "# Numbers to multiply.\n",
-    "qc.x(a[1]) # a = 010 = 2\n",
-    "qc.x(b[0]) # b = 011 = 3\n",
+    "qc.x(a[1]) # a = 10 = 2\n",
+    "qc.x(b[0]) # b = 11 = 3\n",
     "qc.x(b[1])\n",
     "\n",
     "# Multiply the numbers, so |a>|b>|m=0> to |a>|b>|a*b>.\n",
-    "mult(qc, a, b, m, 3)\n",
+    "mult(qc, a, b, m, 2)\n",
     "\n",
     "# Measure the result.\n",
     "qc.measure(m, cm)\n",

--- a/QArithmetic.py
+++ b/QArithmetic.py
@@ -249,6 +249,11 @@ def mult(circ, a, b, c, n):
     for i in range (0, n):
         cadd(circ, a[i], b, sub_qr(c, i, n+i), n)
 
+# Computes the product c=a*b if and only if control.
+# a has length n.
+# b has length n.
+# control has length 1.
+# c has length 2n.
 def cmult(circ, control, a, b, c, n):
     qa = QuantumRegister(len(a))
     qb = QuantumRegister(len(b))

--- a/QArithmetic.py
+++ b/QArithmetic.py
@@ -74,10 +74,13 @@ def carry_dg(circ, cin, a, b, cout):
     circ.ccx(a, b, cout)
 
 # Draper adder that takes |a>|b> to |a>|a+b>.
-# |a> has length n+1 (left padded with a zero).
+# |a> has length x and is less than or equal to n
 # |b> has length n+1 (left padded with a zero).
 # https://arxiv.org/pdf/quant-ph/0008033.pdf
 def add(circ, a, b, n):
+    # move n forward by one to account for overflow
+    n += 1
+
     # Take the QFT.
     qft(circ, b, n)
 
@@ -86,16 +89,21 @@ def add(circ, a, b, n):
     for i in range(n,0,-1):
         # Iterate through the controls.
         for j in range(i,0,-1):
-            circ.cu1(2*pi/2**(i-j+1), a[j-1], b[i-1])
+            # If the qubit a[j-1] exists run ccu, if not assume the qubit is 0 and never existed
+            if len(a) - 1 >= j - 1:
+                circ.cu1(2*pi/2**(i-j+1), a[j-1], b[i-1])
 
     # Take the inverse QFT.
     iqft(circ, b, n)
 
 # Draper adder that takes |a>|b> to |a>|a+b>, controlled on |c>.
-# |a> has length n+1 (left padded with a zero).
+# |a> has length x and is less than or equal to n
 # |b> has length n+1 (left padded with a zero).
 # |c> is a single qubit that's the control.
 def cadd(circ, c, a, b, n):
+    # move n forward by one to account for overflow
+    n += 1
+
     # Take the QFT.
     cqft(circ, c, b, n)
 
@@ -104,7 +112,9 @@ def cadd(circ, c, a, b, n):
     for i in range(n,0,-1):
         # Iterate through the controls.
         for j in range(i,0,-1):
-            ccu1(circ, 2*pi/2**(i-j+1), c, a[j-1], b[i-1])
+            # If the qubit a[j-1] exists run ccu, if not assume the qubit is 0 and never existed
+            if len(a) - 1 >= j - 1:
+                ccu1(circ, 2*pi/2**(i-j+1), c, a[j-1], b[i-1])
 
     # Take the inverse QFT.
     ciqft(circ, c, b, n)

--- a/examples/test_add.py
+++ b/examples/test_add.py
@@ -6,10 +6,10 @@ from QArithmetic import add
 # Input N
 N = 4
 
-a = QuantumRegister(N+1)
+a = QuantumRegister(N)
 b = QuantumRegister(N+1)
 
-ca = ClassicalRegister(N+1)
+ca = ClassicalRegister(N)
 cb = ClassicalRegister(N+1)
 
 qc = QuantumCircuit(a, b, ca, cb)
@@ -25,7 +25,7 @@ qc.x(b[0])
 qc.x(b[1])
 qc.x(b[3])
 
-add(qc, a, b, N+1)
+add(qc, a, b, N)
 
 qc.measure(a, ca)
 qc.measure(b, cb)

--- a/examples/test_cadd.py
+++ b/examples/test_cadd.py
@@ -6,11 +6,11 @@ from QArithmetic import cadd
 # Input N
 N = 4
 
-a = QuantumRegister(N+1)
+a = QuantumRegister(N)
 b = QuantumRegister(N+1)
 c = QuantumRegister(1)
 
-ca = ClassicalRegister(N+1)
+ca = ClassicalRegister(N)
 cb = ClassicalRegister(N+1)
 cc = ClassicalRegister(1)
 
@@ -27,9 +27,9 @@ qc.x(b[0])
 qc.x(b[1])
 qc.x(b[3])
 # c = 0
-#qc.x(c)
+# qc.x(c)
 
-cadd(qc, c, a, b, N+1)
+cadd(qc, c, a, b, N)
 
 qc.measure(a, ca)
 qc.measure(b, cb)

--- a/examples/test_mult.py
+++ b/examples/test_mult.py
@@ -4,7 +4,7 @@ from qiskit import execute, Aer
 from QArithmetic import mult
 
 # Input N
-N = 3
+N = 2
 
 a = QuantumRegister(N)
 b = QuantumRegister(N)
@@ -16,6 +16,7 @@ qc = QuantumCircuit(a, b, m, cm)
 
 # Input
 # a = 010 = 2
+qc.x(a[0])
 qc.x(a[1])
 # b = 011 = 3
 qc.x(b[0])


### PR DESCRIPTION
I have restructured the draper adder functions. `n` now represents the number of significant qubits in the larger register `b`. Addition functions now run without a need for padding of the `a` register. I have also updated all example test files and the main notebook to reflect these changes. Most importantly the multiplication function now runs properly with all input qubits equal to 1 and `n` at the minimum allowed.