### PR TITLE
Added Multiple Control Not Gate

### DIFF
--- a/QArithmetic.py
+++ b/QArithmetic.py
@@ -42,17 +42,33 @@ def rshift(circ, a, n):
         circ.swap(a[i],a[i+1])
 
 ################################################################################
-# Controlled-Toffoli, or Controlled-Controlled-Controlled-NOT
+# Multiple-Controlled-NOT
 ################################################################################
 
-# Define a controlled Toffoli gate
-def cccx(circ,ctrl,a,b,c):
-    anc = QuantumRegister(1)
-    circ.add_register(anc[0])
-    circ.ccx(ctrl,a,anc[0])
-    circ.ccx(b,anc[0],c)
-    circ.ccx(ctrl,a,anc[0])
-    circ.ccx(b,anc[0],c)
+# Variable length Toffoli gate
+# REF: https://github.com/qiskit-community/qiskit-community-tutorials/blob/master/terra/qis_adv/quantum_walk.ipynb
+def cnx(qc, *qubits):
+    if len(qubits) >= 3:
+        last = qubits[-1]
+        # A matrix: (made up of a  and Y rotation, lemma4.3)
+        qc.crz(pi/2, qubits[-2], qubits[-1])
+        qc.cu3(pi/2, 0, 0, qubits[-2],qubits[-1])
+        
+        # Control not gate
+        cnx(qc,*qubits[:-2],qubits[-1])
+        
+        # B matrix (pposite angle)
+        qc.cu3(-pi/2, 0, 0, qubits[-2], qubits[-1])
+        
+        # Control
+        cnx(qc,*qubits[:-2],qubits[-1])
+        
+        # C matrix (final rotation)
+        qc.crz(-pi/2,qubits[-2],qubits[-1])
+    elif len(qubits)==3:
+        qc.ccx(*qubits)
+    elif len(qubits)==2:
+        qc.cx(*qubits)
 
 ################################################################################
 # Addition Circuits

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ List of operations implemented:
 
 > *Source*: [O. Scott, Nathan & Dueck, G.W.. (2008). Pairwise decomposition of toffoli gates in a quantum circuit. 231-236. 10.1145/1366110.1366168](https://www.researchgate.net/publication/220904774_Pairwise_decomposition_of_toffoli_gates_in_a_quantum_circuit). 
 
+#### Multiple Controlled Not gate (qc,ctrl,a...n, z)
+
+    qc->quantum circuit, ctrl->control bit, a->toffoli control input ... n->toffoli control input, z->target qubit
+
+
+> *Source*: [Barenco, Adriano and Bennett, Charles H. and Cleve, Richard and DiVincenzo, David P. and Margolus, Norman and Shor, Peter and Sleator, Tycho and Smolin, John A. and Weinfurter, Harald. (1995). Elementary gates for quantum computation. 3457–3467. 10.1103/physreva.52.3457](http://dx.doi.org/10.1103/PhysRevA.52.3457). 
 #### Logical AND (qc, a, b, c, N)
 
     qc->quantum circuit, a->input1, b->input2, c->output, N->bit-string length


### PR DESCRIPTION
Based off of [this](https://github.com/qiskit-community/qiskit-community-tutorials/blob/master/terra/qis_adv/quantum_walk.ipynb) tutorial from the qiskit community I have added a multiple controlled not gate which replaces the old method `cccx` within QArithmetic.py. This addition allows for the dropping of the ancilla bit used before as well as supporting any number of control bits without any need for ancillary qubits.